### PR TITLE
Fix #14: Add Suffix "-NS" to not score

### DIFF
--- a/src/components/ValueResult.vue
+++ b/src/components/ValueResult.vue
@@ -5,7 +5,7 @@
       <br />
       {{ data.displayValue }}
     </div>
-    <div class="col-md-2"><Modifier :data="data.value" /></div>
+    <div v-if="!data.name.endsWith('-NS')" class="col-md-2"><Modifier :data="data.value" /></div>
   </div>
 </template>
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,8 +19,9 @@ function hasScore(question: IQuestion): boolean {
     question.getType() === "radiogroup" ||
     question.getType() === "checkbox" ||
     question.getType() === "dropdown"
-  ) {
-    return true;
+  ) {    
+    // Allows the exclusion of dropdown fields like department. 
+    return !question.getValueName().endsWith("-NS");
   }
   return false;
 }

--- a/src/survey-enfr.json
+++ b/src/survey-enfr.json
@@ -29,7 +29,7 @@
                         },
                         {
                             "type": "dropdown",
-                            "name": "department",
+                            "name": "department-NS",
                             "title": {
                                 "default": "Department",
                                 "fr": "Ministère"


### PR DESCRIPTION
For the cases where the fields are dropdown, checkbox or radio, if the field name while creating the survey ends with suffix "-NS" for not scored, the field will be skipped as part of the scoring process. 