### PR TITLE
FIX #5: Add Required label and change H5 to label tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+  <link rel="stylesheet"type="text/css" href="<%= BASE_URL %>survey.css">
 
   <!--  CDTS implementation -->
   <script type="text/javascript"

--- a/public/survey.css
+++ b/public/survey.css
@@ -1,0 +1,3 @@
+div.sv_qstn_error_top  span.glyphicon-exclamation-sign {
+    display: none
+}

--- a/src/components/AssessmentTool.vue
+++ b/src/components/AssessmentTool.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!--<h2>Assessment Tool</h2>-->
-    <div id="surveyContainer">
+    <div id="surveyContainer" class="wb-frmvld">
       <survey v-bind:survey="survey"></survey>
     </div>
   </div>

--- a/src/survey-enfr.json
+++ b/src/survey-enfr.json
@@ -17,7 +17,8 @@
                             "title": {
                                 "default": "Name of Respondent",
                                 "fr": "Nom de la personne sondée"
-                            }
+                            },
+                            "isRequired": true
                         },
                         {
                             "type": "text",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -73,21 +73,6 @@ export default class Home extends Vue {
         title.outerHTML = '<label for="'+ options.question.inputId + '" class="' + title.className + '"><span class="field-name">' + title.innerText + '</span>'+ questionRequiredHTML + '</label>';
       }
     });
-
-    this.Survey.onErrorCustomText.add(function(sender, options) {
-      // Delete the extra ! mark shown on error.
-      var questionDom = document.getElementById(options.error.errorOwner.id);
-      if (questionDom) {
-        var spanTags = questionDom.getElementsByTagName("span");
-        console.log(questionDom.innerHTML);
-        for(var idx = 0; idx < spanTags.length; idx++) {
-          var className = spanTags[idx].getAttribute('class');
-          if (className && className.indexOf("glyphicon-exclamation-sign") != -1) {
-            spanTags[idx].remove();
-          }
-        }
-      }
-    });
   }
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -64,14 +64,28 @@ export default class Home extends Vue {
       if (title) {
         var questionRequiredHTML = "";
 
-        if (options.question.isRequired)
-        {
+        if (options.question.isRequired) {
           // Should do localization mechanism
           var requiredText = (sender.locale == 'fr' ? 'obligatoire' : 'required');
           questionRequiredHTML = ' <strong class="required">(' + requiredText + ')</strong>';
         }
 
         title.outerHTML = '<label for="'+ options.question.inputId + '" class="' + title.className + '"><span class="field-name">' + title.innerText + '</span>'+ questionRequiredHTML + '</label>';
+      }
+    });
+
+    this.Survey.onErrorCustomText.add(function(sender, options) {
+      // Delete the extra ! mark shown on error.
+      var questionDom = document.getElementById(options.error.errorOwner.id);
+      if (questionDom) {
+        var spanTags = questionDom.getElementsByTagName("span");
+        console.log(questionDom.innerHTML);
+        for(var idx = 0; idx < spanTags.length; idx++) {
+          var className = spanTags[idx].getAttribute('class');
+          if (className && className.indexOf("glyphicon-exclamation-sign") != -1) {
+            spanTags[idx].remove();
+          }
+        }
       }
     });
   }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -27,7 +27,7 @@ import showdown from "showdown";
     Score
   }
 })
-export default class Home extends Vue {
+export default class Home extends Vue {  
   readonly Survey: Model = new Model(surveyJSON);
   created() {
     this.Survey.onComplete.add(result => {
@@ -52,6 +52,27 @@ export default class Home extends Vue {
       str = str.substring(0, str.length - 4);
       //set html
       options.html = str;
+    });
+
+    // Remove the default required '*'.
+    this.Survey.requiredText = "";
+
+    // Fix all the question labels as they're using <H5> instead of <label> 
+    // as SurveyJS has open issue as per: https://github.com/surveyjs/surveyjs/issues/928 
+    this.Survey.onAfterRenderQuestion.add(function (sender, options) {
+      let title = options.htmlElement.getElementsByTagName("H5")[0];
+      if (title) {
+        var questionRequiredHTML = "";
+
+        if (options.question.isRequired)
+        {
+          // Should do localization mechanism
+          var requiredText = (sender.locale == 'fr' ? 'obligatoire' : 'required');
+          questionRequiredHTML = ' <strong class="required">(' + requiredText + ')</strong>';
+        }
+
+        title.outerHTML = '<label for="'+ options.question.inputId + '" class="' + title.className + '"><span class="field-name">' + title.innerText + '</span>'+ questionRequiredHTML + '</label>';
+      }
     });
   }
 }


### PR DESCRIPTION
@CalvinRodo @gcharest 

**Don't merge**

Items for discussion
- [X] Changed the ```<H5>``` tags used for question labels to ```<label>```
- [x] Localization can be done better, suggestions for the "required" text or leave as is. 
- [x] Seems WET and SurveyJS adds error "!" for alert boxes, so which one we keeping?