### PR TITLE
Removed the details and summary sections

### DIFF
--- a/src/components/Obligations.vue
+++ b/src/components/Obligations.vue
@@ -1,28 +1,22 @@
 <template>
   <div class="requirements">
     <div class="container-fluid">
-      <ul class="list-unstyled">
-        <li>
-          <details>
-            <summary>{{ $t("requirements.title") }} {{ score[3] }}</summary>
-            <div
-              class="row"
-              v-for="requirement in $t('requirements.elements')"
-              :key="requirement.title"
-            >
-              <h3>{{ requirement.title }}</h3>
-              <p>{{ requirement.elements[score[3] - 1].text }}</p>
-            </div>
-          </details>
-        </li>
-        <li>
-          <p>
-            <a :href="$t('linkDirective')" target="_blank">
-              {{ $t("linkDirectiveText") }}
-            </a>
-          </p>
-        </li>
-      </ul>
+      <div class="row">
+        <h2 id="obligations">{{ $t("requirements.title") }} {{ score[3] }}</h2>
+      </div>
+      <div
+        class="row"
+        v-for="requirement in $t('requirements.elements')"
+        :key="requirement.title"
+      >
+        <h3>{{ requirement.title }}</h3>
+        <p>{{ requirement.elements[score[3] - 1].text }}</p>
+      </div>
+      <p class="row">
+        <a :href="$t('linkDirective')" target="_blank">
+          {{ $t("linkDirectiveText") }}
+        </a>
+      </p>
     </div>
   </div>
 </template>

--- a/src/components/Score.vue
+++ b/src/components/Score.vue
@@ -1,5 +1,5 @@
 <template>
-  <section :class="alertclass">
+  <section :class="alertclass" id="score">
     <p>{{ $t("riskLevel") }} {{ score[3] }}</p>
     <p>{{ $t("currentScore") }} {{ score[2] }}</p>
     <p>{{ $t("rawRiskScore") }} {{ score[0] }}</p>

--- a/src/plugins/en.json
+++ b/src/plugins/en.json
@@ -1,5 +1,6 @@
 {
     "swtchLang": "Français",
+    "onThisPage": "On this page",
     "htmlCode": "en-CA",
     "appTitle": "Algorithmic Impact Assessment",
     "linkProjectText": "Link to GitHub project repository",

--- a/src/plugins/fr.json
+++ b/src/plugins/fr.json
@@ -1,5 +1,6 @@
 {
     "swtchLang": "English",
+    "onThisPage": "Sur cette page",
     "htmlCode": "fr-CA",
     "appTitle": "Évaluation de l'Incidence Algorithmique",
     "linkProjectText": "Lien vers le répertoire GitHub du projet",

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -2,63 +2,69 @@
   <div class="results">
     <!--<PrintButton />-->
     <h1>{{ $t("resultTitle") }}</h1>
+
+    <p>{{ $t("onThisPage") }}</p>
+    <ul>
+      <li>
+        <a href="#score">{{ $t("riskLevel") }}</a>
+      </li>
+      <li>
+        <a href="#obligations">{{ $t("requirements.title") }}</a>
+      </li>
+      <li>
+        <a href="#mitigationMeasures">{{ $t("resultSectionMeasure") }}</a>
+      </li>
+      <li>
+        <a href="#qA">{{ $t("resultSectionQA") }}</a>
+        <ul>
+          <li>
+            <a href="#projectDetails">{{ $t("resultSectionPD") }}</a>
+          </li>
+          <li>
+            <a href="#riskQA">{{ $t("resultSectionRQA") }}</a>
+          </li>
+          <li>
+            <a href="#mitigationQA">{{ $t("resultSectionMQA") }}</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
+
     <Score />
     <Obligations />
 
     <div class="container-fluid">
-      <ul class="list-unstyled">
-        <li>
-          <details>
-            <summary>{{ $t("resultSectionMeasure") }}</summary>
-            <div class="row" v-for="result in myResults[3]" :key="result.name">
-              <Result :data="result"></Result>
-            </div>
-          </details>
-        </li>
-        <li>
-          <details>
-            <summary>{{ $t("resultSectionQA") }}</summary>
-            <ul class="list-unstyled">
-              <li>
-                <details>
-                  <summary>{{ $t("resultSectionPD") }}</summary>
-                  <div
-                    class="row"
-                    v-for="result in myResults[0]"
-                    :key="result.name"
-                  >
-                    <Result :data="result"></Result>
-                  </div>
-                </details>
-              </li>
-              <li>
-                <details>
-                  <summary>{{ $t("resultSectionRQA") }}</summary>
-                  <div
-                    class="row"
-                    v-for="result in myResults[1]"
-                    :key="result.name"
-                  >
-                    <Result :data="result"></Result>
-                  </div>
-                </details>
-              </li>
-              <li>
-                <details>
-                  <summary>{{ $t("resultSectionMQA") }}</summary>
-                  <div
-                    class="row"
-                    v-for="result in myResults[2]"
-                    :key="result.name"
-                  >
-                    <Result :data="result"></Result>
-                  </div>
-                </details>
-              </li>
-            </ul>
-          </details>
-        </li>
-      </ul>
+      <div class="row">
+        <h2 id="mitigationMeasures">{{ $t("resultSectionMeasure") }}</h2>
+      </div>
+      <div class="row" v-for="result in myResults[3]" :key="result.name">
+        <Result :data="result"></Result>
+      </div>
+
+      <div class="row">
+        <h2 id="qA">{{ $t("resultSectionQA") }}</h2>
+      </div>
+
+      <div class="row">
+        <h3 id="projectDetails">{{ $t("resultSectionPD") }}</h3>
+      </div>
+      <div class="row" v-for="result in myResults[0]" :key="result.name">
+        <Result :data="result"></Result>
+      </div>
+
+      <div class="row">
+        <h3 id="riskQA">{{ $t("resultSectionRQA") }}</h3>
+      </div>
+      <div class="row" v-for="result in myResults[1]" :key="result.name">
+        <Result :data="result"></Result>
+      </div>
+
+      <div class="row">
+        <h3 id="mitigationQA">{{ $t("resultSectionMQA") }}</h3>
+      </div>
+      <div class="row" v-for="result in myResults[2]" :key="result.name">
+        <Result :data="result"></Result>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
There is a bug in how ie 11 renders the expandable detail summarys.

It doesn't.

So instead of tracking down what was the issue because it wasn't immediately obvious, I've removed them converted the page to a single page and then added a table of contents to the beginning as per the Canada.Ca style guide design pattern for an in page table of contents

https://design.canada.ca/common-design-patterns/in-page-toc.html