### PR TITLE
Fixing type assertions

### DIFF
--- a/src/components/SaveLoadFile.vue
+++ b/src/components/SaveLoadFile.vue
@@ -1,74 +1,78 @@
 <template>
   <div>
-      <button type="button" class="mrgn-bttm-sm btn btn-success" v-on:click="saveSurvey">
-        Save
-      </button>
-      <input type="file" class="btn btn-default" value="Load" @change="onFileChanged($event)"/>
+    <button
+      type="button"
+      class="mrgn-bttm-sm btn btn-success"
+      v-on:click="saveSurvey"
+    >
+      Save
+    </button>
+    <input
+      type="file"
+      class="btn btn-default"
+      value="Load"
+      @change="onFileChanged($event)"
+    />
   </div>
 </template>
 
 <script lang="ts">
-
 import { Component, Vue } from "vue-property-decorator";
 import showdown from "showdown";
 import i18n from "@/plugins/i18n";
 import SurveyFile from "@/interfaces/SurveyFile";
 
-
 @Component
 export default class SaveLoadFile extends Vue {
+  // saveSurvey() {
 
-  saveSurvey() { 
+  //   const a = document.createElement('a');
+  //   a.download = "SurveyResults.json";
 
+  //   const saveFile = this.$store.getters.SurveyFile;
+  //   const blob = new Blob([saveFile], {type: 'text/plain'})
 
-    const a = document.createElement('a');
-    a.download = "SurveyResults.json";
+  //   a.href = window.URL.createObjectURL(blob);
 
-    const saveFile = this.$store.getters.SurveyFile;
-    const blob = new Blob([saveFile], {type: 'text/plain'})
+  //   a.dataset.downloadurl = ['text/json', a.download, a.href].join(':');
 
-    a.href = window.URL.createObjectURL(blob);
+  //   const e = document.createEvent('MouseEvents');
+  //   e.initEvent('click', true, false);
+  //   a.dispatchEvent(e);
+  // }
 
-    a.dataset.downloadurl = ['text/json', a.download, a.href].join(':');
-
-    const e = document.createEvent('MouseEvents');
-    e.initEvent('click', true, false);
-    a.dispatchEvent(e);
-  }
-
-  onFileChanged($event : any) {
-
-    if ($event === null ||
-        $event.target === null ||
-        $event.dataTransfer === null){ 
+  onFileChanged($event: any) {
+    if (
+      $event === null ||
+      $event.target === null ||
+      $event.dataTransfer === null
+    ) {
       return;
     }
 
-    const files = (<HTMLInputElement>$event.target).files ||
-                  $event.dataTransfer.files;
+    const target = $event.target as HTMLInputElement;
+    const files = target.files || $event.dataTransfer.files;
 
-    if (files.length === 0){
+    if (files.length === 0) {
       return;
     }
 
     this.loadSurvey(files[0]);
   }
 
-  loadSurvey(file : any){ 
+  loadSurvey(file: any) {
     const reader = new FileReader();
     reader.onload = (e: ProgressEvent) => {
-      
-      if (<string>reader.result === "undefined") {
-        return; 
+      const result = reader.result as string;
+      if (result === "undefined") {
+        return;
       }
 
-      const loadedFile : SurveyFile = JSON.parse(<string>reader.result);
-      this.$emit('fileLoaded', loadedFile);
-    }
+      const loadedFile: SurveyFile = JSON.parse(result);
+      this.$emit("fileLoaded", loadedFile);
+    };
 
     reader.readAsText(file);
   }
-
 }
 </script>
-


### PR DESCRIPTION
We were using the `<Foo>` style assertions instead of the recommended `as Foo` style assertions. This was causing an issue with eslint where it was flagging an error and then not linting the rest of the file.