### PR TITLE
Revert vuex-persist to 1.8.0 re: IE issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15245,7 +15245,7 @@
       "integrity": "sha512-mdHeHT/7u4BncpUZMlxNaIdcN/HIt1GsGG5LKByArvYG/v6DvHcOxvDCts+7SRdCoIRGllK8IMZvQtQXLppDYg=="
     },
     "vuex-persist": {
-      "version": "2.0.1",
+      "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/vuex-persist/-/vuex-persist-2.0.1.tgz",
       "integrity": "sha512-V3WSBYmxcAP6ei0VVt2lxGloeWJZgk1Ao4r+iOxLMhAv+UYIK91qbjwvqk6Xr3tAi052jzSwn8aoamtuz8ArsQ==",
       "requires": {


### PR DESCRIPTION
We're having an issue with IE not rendering the app. Seems to be related to vuex-persist version.

Reverting to 1.8.0 fixes the issue based on this https://github.com/championswimmer/vuex-persist/issues/73