### PR TITLE
Revert departments keys to origin

### DIFF
--- a/src/survey-enfr.json
+++ b/src/survey-enfr.json
@@ -53,710 +53,710 @@
                             },
                             "choices": [
                                 {
-                                    "value": "item170",
-                                    "text": {
-                                        "default": "Administrative Tribunals Support Service of Canada",
-                                        "fr": "Administration du pipe-line du Nord"
-                                    }
-                                },
-                                {
-                                    "value": "item001",
+                                    "value": "001",
                                     "text": {
                                         "default": "Agriculture and Agri-Food (Department of)",
-                                        "fr": "Affaires indiennes et du Nord canadien (Ministère des)"
-                                    }
-                                },
-                                {
-                                    "value": "item023",
-                                    "text": {
-                                        "default": "Atlantic Canada Opportunities Agency",
-                                        "fr": "Affaires étrangères, du Commerce et du Développement (Ministère des)"
-                                    }
-                                },
-                                {
-                                    "value": "item085",
-                                    "text": {
-                                        "default": "Canada Border ServiI was not hired to toces Agency",
-                                        "fr": "Agence Parcs Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item038",
-                                    "text": {
-                                        "default": "Canada Border Services Agency - (Administered Activities)",
-                                        "fr": "Agence canadienne d'inspection des aliments"
-                                    }
-                                },
-                                {
-                                    "value": "item091",
-                                    "text": {
-                                        "default": "Canada Mortgage and Housing Corporation (Crown Corporation)",
-                                        "fr": "Agence canadienne de développement économique du Nord"
-                                    }
-                                },
-                                {
-                                    "value": "item130",
-                                    "text": {
-                                        "default": "Canada Revenue Agency",
-                                        "fr": "Agence de développement économique du Canada pour les régions du Québec"
-                                    }
-                                },
-                                {
-                                    "value": "item122",
-                                    "text": {
-                                        "default": "Canada Revenue Agency - (Administered Activities)",
-                                        "fr": "Agence de la consommation en matière financière du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item052",
-                                    "text": {
-                                        "default": "Canada School of Public Service",
-                                        "fr": "Agence de la santé publique du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item100",
-                                    "text": {
-                                        "default": "Canadian Centre for Occupational Health and Safety",
-                                        "fr": "Agence de promotion économique du Canada atlantique"
-                                    }
-                                },
-                                {
-                                    "value": "item134",
-                                    "text": {
-                                        "default": "Canadian Dairy Commission",
-                                        "fr": "Agence des services frontaliers du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item136",
-                                    "text": {
-                                        "default": "Canadian Food Inspection Agency",
-                                        "fr": "Agence des services frontaliers du Canada - (activités administrées)"
-                                    }
-                                },
-                                {
-                                    "value": "item133",
-                                    "text": {
-                                        "default": "Canadian Grain Commission",
-                                        "fr": "Agence du revenu du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item135",
-                                    "text": {
-                                        "default": "Canadian Heritage (Department of)",
-                                        "fr": "Agence du revenu du Canada - (activités administrées)"
-                                    }
-                                },
-                                {
-                                    "value": "item171",
-                                    "text": {
-                                        "default": "Canadian High Arctic Research Station",
-                                        "fr": "Agence fédérale de développement économique pour le Sud de l'Ontario"
-                                    }
-                                },
-                                {
-                                    "value": "item075",
-                                    "text": {
-                                        "default": "Canadian Human Rights Commission",
-                                        "fr": "Agence spatiale canadienne"
-                                    }
-                                },
-                                {
-                                    "value": "item061",
-                                    "text": {
-                                        "default": "Canadian Institutes of Health Research",
                                         "fr": "Agriculture et de l'Agroalimentaire (Ministère de l')"
                                     }
                                 },
                                 {
-                                    "value": "item043",
+                                    "value": "002",
                                     "text": {
-                                        "default": "Canadian Intergovernmental Conference Secretariat",
-                                        "fr": "Anciens Combattants (Ministère des)"
-                                    }
-                                },
-                                {
-                                    "value": "item078",
-                                    "text": {
-                                        "default": "Canadian Northern Economic Development Agency",
-                                        "fr": "Bibliothèque du Parlement"
-                                    }
-                                },
-                                {
-                                    "value": "item047",
-                                    "text": {
-                                        "default": "Canadian Nuclear Safety Commission",
-                                        "fr": "Bibliothèque et Archives du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item016",
-                                    "text": {
-                                        "default": "Canadian Radio-television and Telecommunications Commission",
-                                        "fr": "Bureau canadien d'enquête sur les accidents de transport et de la sécurité des transports"
-                                    }
-                                },
-                                {
-                                    "value": "item095",
-                                    "text": {
-                                        "default": "Canadian Security Intelligence Service",
-                                        "fr": "Bureau de l'infrastructure du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item119",
-                                    "text": {
-                                        "default": "Canadian Space Agency",
-                                        "fr": "Bureau de la coordonnatrice de la situation de la femme"
-                                    }
-                                },
-                                {
-                                    "value": "item101",
-                                    "text": {
-                                        "default": "Canadian Transportation Accident Investigation and Safety Board",
-                                        "fr": "Bureau du Conseil privé"
-                                    }
-                                },
-                                {
-                                    "value": "item040",
-                                    "text": {
-                                        "default": "Canadian Transportation Agency",
-                                        "fr": "Bureau du commissaire du Centre de la sécurité des télécommunications"
-                                    }
-                                },
-                                {
-                                    "value": "item050",
-                                    "text": {
-                                        "default": "Citizenship and Immigration (Department of)",
-                                        "fr": "Bureau du commissaire à la magistrature fédérale"
-                                    }
-                                },
-                                {
-                                    "value": "item165",
-                                    "text": {
-                                        "default": "Communications Security Establishment",
-                                        "fr": "Bureau du conseiller sénatorial en éthique"
-                                    }
-                                },
-                                {
-                                    "value": "item116",
-                                    "text": {
-                                        "default": "Copyright Board",
-                                        "fr": "Bureau du directeur des poursuites pénales"
-                                    }
-                                },
-                                {
-                                    "value": "item053",
-                                    "text": {
-                                        "default": "Correctional Service of Canada",
-                                        "fr": "Bureau du directeur général des élections"
-                                    }
-                                },
-                                {
-                                    "value": "item144",
-                                    "text": {
-                                        "default": "Courts Administration Service",
-                                        "fr": "Bureau du directeur parlementaire du budget"
-                                    }
-                                },
-                                {
-                                    "value": "item012",
-                                    "text": {
-                                        "default": "Economic Development Agency of Canada for the Regions of Quebec",
-                                        "fr": "Bureau du secrétaire du gouverneur général"
-                                    }
-                                },
-                                {
-                                    "value": "item014",
-                                    "text": {
-                                        "default": "Employment and Social Development (Department of)",
-                                        "fr": "Bureau du surintendant des institutions financières"
-                                    }
-                                },
-                                {
-                                    "value": "item007",
-                                    "text": {
-                                        "default": "Environment (Department of the)",
+                                        "default": "Office of the Auditor General",
                                         "fr": "Bureau du vérificateur général"
                                     }
                                 },
                                 {
-                                    "value": "item123",
+                                    "value": "004",
                                     "text": {
-                                        "default": "Export Development Canada (Crown Corporation)",
-                                        "fr": "Centre canadien d'hygiène et de sécurité au travail"
-                                    }
-                                },
-                                {
-                                    "value": "item062",
-                                    "text": {
-                                        "default": "Federal Economic Development Agency for Southern Ontario",
-                                        "fr": "Centre d'analyse des opérations et déclarations financières du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item006",
-                                    "text": {
-                                        "default": "Finance (Department of)",
-                                        "fr": "Centre de la sécurité des télécommunications"
-                                    }
-                                },
-                                {
-                                    "value": "item141",
-                                    "text": {
-                                        "default": "Financial Consumer Agency of Canada",
-                                        "fr": "Chambre des communes"
-                                    }
-                                },
-                                {
-                                    "value": "item139",
-                                    "text": {
-                                        "default": "Financial Transactions and Reports Analysis Centre of Canada",
-                                        "fr": "Citoyenneté et de l'Immigration (Ministère de la)"
-                                    }
-                                },
-                                {
-                                    "value": "item086",
-                                    "text": {
-                                        "default": "Fisheries and Oceans (Department of)",
-                                        "fr": "Comité de surveillance des activités de renseignement de sécurité"
-                                    }
-                                },
-                                {
-                                    "value": "item005",
-                                    "text": {
-                                        "default": "Foreign Affairs, Trade and Development (Department of)",
-                                        "fr": "Comité externe d'examen des griefs militaires"
-                                    }
-                                },
-                                {
-                                    "value": "item022",
-                                    "text": {
-                                        "default": "Health (Department of)",
-                                        "fr": "Commissariat au lobbying"
-                                    }
-                                },
-                                {
-                                    "value": "item067",
-                                    "text": {
-                                        "default": "House of Commons",
-                                        "fr": "Commissariat aux conflits d'intérêts et à l'éthique"
-                                    }
-                                },
-                                {
-                                    "value": "item032",
-                                    "text": {
-                                        "default": "Immigration and Refugee Board",
-                                        "fr": "Commissariat aux langues officielles"
-                                    }
-                                },
-                                {
-                                    "value": "item042",
-                                    "text": {
-                                        "default": "Indian Affairs and Northern Development (Department of)",
-                                        "fr": "Commissariat à l'intégrité du secteur public"
-                                    }
-                                },
-                                {
-                                    "value": "item033",
-                                    "text": {
-                                        "default": "Industry (Department of)",
-                                        "fr": "Commissariats à l'information et à la protection de la vie privée au Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item024",
-                                    "text": {
-                                        "default": "International Joint Commission (Canadian Section)",
-                                        "fr": "Commission canadienne de sûreté nucléaire"
-                                    }
-                                },
-                                {
-                                    "value": "item180",
-                                    "text": {
-                                        "default": "Invest in Canada Hub",
-                                        "fr": "Commission canadienne des droits de la personne"
-                                    }
-                                },
-                                {
-                                    "value": "item013",
-                                    "text": {
-                                        "default": "Justice (Department of)",
-                                        "fr": "Commission canadienne des grains"
-                                    }
-                                },
-                                {
-                                    "value": "item145",
-                                    "text": {
-                                        "default": "Library and Archives of Canada",
-                                        "fr": "Commission canadienne du lait"
-                                    }
-                                },
-                                {
-                                    "value": "item017",
-                                    "text": {
-                                        "default": "Library of Parliament",
-                                        "fr": "Commission d'examen des plaintes concernant la police militaire"
-                                    }
-                                },
-                                {
-                                    "value": "item138",
-                                    "text": {
-                                        "default": "Military Grievances External Review Committee",
-                                        "fr": "Commission de l'immigration et du statut de réfugié"
-                                    }
-                                },
-                                {
-                                    "value": "item137",
-                                    "text": {
-                                        "default": "Military Police Complaints Commission",
+                                        "default": "Public Service Commission",
                                         "fr": "Commission de la fonction publique"
                                     }
                                 },
                                 {
-                                    "value": "item018",
+                                    "value": "005",
                                     "text": {
-                                        "default": "National Defence (Department of)",
-                                        "fr": "Commission des champs de bataille nationaux"
+                                        "default": "Foreign Affairs, Trade and Development (Department of)",
+                                        "fr": "Affaires étrangères, du Commerce et du Développement (Ministère des)"
                                     }
                                 },
                                 {
-                                    "value": "item074",
+                                    "value": "006",
                                     "text": {
-                                        "default": "National Energy Board",
-                                        "fr": "Commission des libérations conditionnelles du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item039",
-                                    "text": {
-                                        "default": "National Film Board",
-                                        "fr": "Commission du droit d'auteur"
-                                    }
-                                },
-                                {
-                                    "value": "item035",
-                                    "text": {
-                                        "default": "National Research Council of Canada",
-                                        "fr": "Commission mixte internationale (section canadienne)"
-                                    }
-                                },
-                                {
-                                    "value": "item041",
-                                    "text": {
-                                        "default": "Natural Resources (Department of)",
-                                        "fr": "Conseil d'examen du prix des médicaments brevetés"
-                                    }
-                                },
-                                {
-                                    "value": "item027",
-                                    "text": {
-                                        "default": "Natural Sciences and Engineering Research Council",
-                                        "fr": "Conseil de la radiodiffusion et des télécommunications canadiennes"
-                                    }
-                                },
-                                {
-                                    "value": "item066",
-                                    "text": {
-                                        "default": "Northern Pipeline Agency",
-                                        "fr": "Conseil de recherches en sciences humaines"
-                                    }
-                                },
-                                {
-                                    "value": "item142",
-                                    "text": {
-                                        "default": "Office of Infrastructure of Canada",
-                                        "fr": "Conseil de recherches en sciences naturelles et en génie"
-                                    }
-                                },
-                                {
-                                    "value": "item002",
-                                    "text": {
-                                        "default": "Office of the Auditor General",
-                                        "fr": "Conseil national de recherches du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item015",
-                                    "text": {
-                                        "default": "Office of the Chief Electoral Officer",
-                                        "fr": "Diversification de l'économie de l'Ouest canadien (Ministère de la)"
-                                    }
-                                },
-                                {
-                                    "value": "item083",
-                                    "text": {
-                                        "default": "Office of the Co-ordinator, Status of Women",
-                                        "fr": "Défense nationale (Ministère de la)"
-                                    }
-                                },
-                                {
-                                    "value": "item051",
-                                    "text": {
-                                        "default": "Office of the Commissioner for Federal Judicial Affairs",
-                                        "fr": "Emploi et du Développement social (Ministère de l')"
-                                    }
-                                },
-                                {
-                                    "value": "item154",
-                                    "text": {
-                                        "default": "Office of the Commissioner of Lobbying",
-                                        "fr": "Environnement (Ministère de l')"
-                                    }
-                                },
-                                {
-                                    "value": "item076",
-                                    "text": {
-                                        "default": "Office of the Commissioner of Official Languages",
-                                        "fr": "Exportation et développement Canada (Société d'État)"
-                                    }
-                                },
-                                {
-                                    "value": "item055",
-                                    "text": {
-                                        "default": "Office of the Communications Security Establishment Commissioner",
+                                        "default": "Finance (Department of)",
                                         "fr": "Finances (Ministère des)"
                                     }
                                 },
                                 {
-                                    "value": "item147",
+                                    "value": "007",
                                     "text": {
-                                        "default": "Office of the Conflict of Interest and Ethics Commissioner",
-                                        "fr": "Gendarmerie royale du Canada"
+                                        "default": "Environment (Department of the)",
+                                        "fr": "Environnement (Ministère de l')"
                                     }
                                 },
                                 {
-                                    "value": "item019",
-                                    "text": {
-                                        "default": "Office of the Director of Public Prosecutions",
-                                        "fr": "Grand livre général du système de la paye"
-                                    }
-                                },
-                                {
-                                    "value": "item008",
+                                    "value": "008",
                                     "text": {
                                         "default": "Office of the Governor General's Secretary",
-                                        "fr": "Industrie (Ministère de l')"
+                                        "fr": "Bureau du secrétaire du gouverneur général"
                                     }
                                 },
                                 {
-                                    "value": "item183",
-                                    "text": {
-                                        "default": "Office of the Parliamentary Budget Officer",
-                                        "fr": "Instituts de recherche en santé du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item046",
-                                    "text": {
-                                        "default": "Office of the Public Sector Integrity Commissioner",
-                                        "fr": "Investir au Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item151",
-                                    "text": {
-                                        "default": "Office of the Senate Ethics Officer",
-                                        "fr": "Justice (Ministère de la)"
-                                    }
-                                },
-                                {
-                                    "value": "item011",
-                                    "text": {
-                                        "default": "Office of the Superintendent of Financial Institutions",
-                                        "fr": "Office des transports du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item096",
-                                    "text": {
-                                        "default": "Offices of the Information and Privacy Commissioners of Canada",
-                                        "fr": "Office national de l'énergie"
-                                    }
-                                },
-                                {
-                                    "value": "item124",
-                                    "text": {
-                                        "default": "Parks Canada Agency",
-                                        "fr": "Office national du film"
-                                    }
-                                },
-                                {
-                                    "value": "item176",
-                                    "text": {
-                                        "default": "Parliamentary Protective Service",
-                                        "fr": "Patrimoine canadien (Ministère du)"
-                                    }
-                                },
-                                {
-                                    "value": "item057",
-                                    "text": {
-                                        "default": "Parole Board of Canada",
-                                        "fr": "Pension de retraite de la fonction publique"
-                                    }
-                                },
-                                {
-                                    "value": "item109",
-                                    "text": {
-                                        "default": "Patented Medicine Prices Review Board",
-                                        "fr": "Pêches et des Océans (Ministère des)"
-                                    }
-                                },
-                                {
-                                    "value": "item079",
-                                    "text": {
-                                        "default": "Payroll System General Ledger",
-                                        "fr": "Receveur général"
-                                    }
-                                },
-                                {
-                                    "value": "item025",
-                                    "text": {
-                                        "default": "Privy Council Office",
-                                        "fr": "Registraire de la Cour suprême du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item148",
-                                    "text": {
-                                        "default": "Public Health Agency of Canada",
-                                        "fr": "Ressources naturelles (Ministère des)"
-                                    }
-                                },
-                                {
-                                    "value": "item088",
-                                    "text": {
-                                        "default": "Public Safety and Emergency Preparedness (Department of)",
-                                        "fr": "Santé (Ministère de la)"
-                                    }
-                                },
-                                {
-                                    "value": "item004",
-                                    "text": {
-                                        "default": "Public Service Commission",
-                                        "fr": "Secrétariat des conférences intergouvernementales canadiennes"
-                                    }
-                                },
-                                {
-                                    "value": "item087",
-                                    "text": {
-                                        "default": "Public Service Superannuation",
-                                        "fr": "Secrétariat du Comité des parlementaires sur la sécurité nationale et le renseignement"
-                                    }
-                                },
-                                {
-                                    "value": "item127",
-                                    "text": {
-                                        "default": "Public Works and Government Services (Department of)",
-                                        "fr": "Secrétariat du Conseil du Trésor"
-                                    }
-                                },
-                                {
-                                    "value": "item097",
-                                    "text": {
-                                        "default": "Receiver General",
-                                        "fr": "Service administratif des tribunaux judiciaires"
-                                    }
-                                },
-                                {
-                                    "value": "item080",
-                                    "text": {
-                                        "default": "Registrar of the Supreme Court of Canada",
-                                        "fr": "Service canadien d'appui aux tribunaux administratifs"
-                                    }
-                                },
-                                {
-                                    "value": "item030",
-                                    "text": {
-                                        "default": "Royal Canadian Mounted Police",
-                                        "fr": "Service canadien du renseignement de sécurité"
-                                    }
-                                },
-                                {
-                                    "value": "item192",
-                                    "text": {
-                                        "default": "Secretariat of the National Security and Intelligence Committee of Parliamentarians",
-                                        "fr": "Service correctionnel du Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item103",
-                                    "text": {
-                                        "default": "Security Intelligence Review Committee",
-                                        "fr": "Service de protection parlementaire"
-                                    }
-                                },
-                                {
-                                    "value": "item009",
+                                    "value": "009",
                                     "text": {
                                         "default": "Senate",
-                                        "fr": "Services partagés Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item163",
-                                    "text": {
-                                        "default": "Shared Services Canada",
-                                        "fr": "Société canadienne d'hypothèques et de logement (Société d'État)"
-                                    }
-                                },
-                                {
-                                    "value": "item063",
-                                    "text": {
-                                        "default": "Social Sciences and Humanities Research Council",
-                                        "fr": "Station canadienne de recherche dans l'Extrême-Arctique"
-                                    }
-                                },
-                                {
-                                    "value": "item054",
-                                    "text": {
-                                        "default": "Statistics Canada",
-                                        "fr": "Statistique Canada"
-                                    }
-                                },
-                                {
-                                    "value": "item037",
-                                    "text": {
-                                        "default": "Telefilm Canada",
-                                        "fr": "Sécurité publique et de la Protection civile (Ministère de la)"
-                                    }
-                                },
-                                {
-                                    "value": "item102",
-                                    "text": {
-                                        "default": "The National Battlefields Commission",
                                         "fr": "Sénat"
                                     }
                                 },
                                 {
-                                    "value": "item034",
+                                    "value": "011",
+                                    "text": {
+                                        "default": "Office of the Superintendent of Financial Institutions",
+                                        "fr": "Bureau du surintendant des institutions financières"
+                                    }
+                                },
+                                {
+                                    "value": "012",
+                                    "text": {
+                                        "default": "Economic Development Agency of Canada for the Regions of Quebec",
+                                        "fr": "Agence de développement économique du Canada pour les régions du Québec"
+                                    }
+                                },
+                                {
+                                    "value": "013",
+                                    "text": {
+                                        "default": "Justice (Department of)",
+                                        "fr": "Justice (Ministère de la)"
+                                    }
+                                },
+                                {
+                                    "value": "014",
+                                    "text": {
+                                        "default": "Employment and Social Development (Department of)",
+                                        "fr": "Emploi et du Développement social (Ministère de l')"
+                                    }
+                                },
+                                {
+                                    "value": "015",
+                                    "text": {
+                                        "default": "Office of the Chief Electoral Officer",
+                                        "fr": "Bureau du directeur général des élections"
+                                    }
+                                },
+                                {
+                                    "value": "016",
+                                    "text": {
+                                        "default": "Canadian Radio-television and Telecommunications Commission",
+                                        "fr": "Conseil de la radiodiffusion et des télécommunications canadiennes"
+                                    }
+                                },
+                                {
+                                    "value": "017",
+                                    "text": {
+                                        "default": "Library of Parliament",
+                                        "fr": "Bibliothèque du Parlement"
+                                    }
+                                },
+                                {
+                                    "value": "018",
+                                    "text": {
+                                        "default": "National Defence (Department of)",
+                                        "fr": "Défense nationale (Ministère de la)"
+                                    }
+                                },
+                                {
+                                    "value": "019",
+                                    "text": {
+                                        "default": "Office of the Director of Public Prosecutions",
+                                        "fr": "Bureau du directeur des poursuites pénales"
+                                    }
+                                },
+                                {
+                                    "value": "021",
+                                    "text": {
+                                        "default": "Veterans Affairs (Department of)",
+                                        "fr": "Anciens Combattants (Ministère des)"
+                                    }
+                                },
+                                {
+                                    "value": "022",
+                                    "text": {
+                                        "default": "Health (Department of)",
+                                        "fr": "Santé (Ministère de la)"
+                                    }
+                                },
+                                {
+                                    "value": "023",
+                                    "text": {
+                                        "default": "Atlantic Canada Opportunities Agency",
+                                        "fr": "Agence de promotion économique du Canada atlantique"
+                                    }
+                                },
+                                {
+                                    "value": "024",
+                                    "text": {
+                                        "default": "International Joint Commission (Canadian Section)",
+                                        "fr": "Commission mixte internationale (section canadienne)"
+                                    }
+                                },
+                                {
+                                    "value": "025",
+                                    "text": {
+                                        "default": "Privy Council Office",
+                                        "fr": "Bureau du Conseil privé"
+                                    }
+                                },
+                                {
+                                    "value": "027",
+                                    "text": {
+                                        "default": "Natural Sciences and Engineering Research Council",
+                                        "fr": "Conseil de recherches en sciences naturelles et en génie"
+                                    }
+                                },
+                                {
+                                    "value": "030",
+                                    "text": {
+                                        "default": "Royal Canadian Mounted Police",
+                                        "fr": "Gendarmerie royale du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "032",
+                                    "text": {
+                                        "default": "Immigration and Refugee Board",
+                                        "fr": "Commission de l'immigration et du statut de réfugié"
+                                    }
+                                },
+                                {
+                                    "value": "033",
+                                    "text": {
+                                        "default": "Industry (Department of)",
+                                        "fr": "Industrie (Ministère de l')"
+                                    }
+                                },
+                                {
+                                    "value": "034",
                                     "text": {
                                         "default": "Transport (Department of)",
                                         "fr": "Transports (Ministère des)"
                                     }
                                 },
                                 {
-                                    "value": "item056",
+                                    "value": "035",
                                     "text": {
-                                        "default": "Treasury Board Secretariat",
-                                        "fr": "Travaux publics et des Services gouvernementaux (Ministère des)"
+                                        "default": "National Research Council of Canada",
+                                        "fr": "Conseil national de recherches du Canada"
                                     }
                                 },
                                 {
-                                    "value": "item021",
+                                    "value": "037",
                                     "text": {
-                                        "default": "Veterans Affairs (Department of)",
+                                        "default": "Telefilm Canada",
                                         "fr": "Téléfilm Canada"
                                     }
                                 },
                                 {
-                                    "value": "item044",
+                                    "value": "038",
+                                    "text": {
+                                        "default": "Canada Border Services Agency - (Administered Activities)",
+                                        "fr": "Agence des services frontaliers du Canada - (activités administrées)"
+                                    }
+                                },
+                                {
+                                    "value": "039",
+                                    "text": {
+                                        "default": "National Film Board",
+                                        "fr": "Office national du film"
+                                    }
+                                },
+                                {
+                                    "value": "040",
+                                    "text": {
+                                        "default": "Canadian Transportation Agency",
+                                        "fr": "Office des transports du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "041",
+                                    "text": {
+                                        "default": "Natural Resources (Department of)",
+                                        "fr": "Ressources naturelles (Ministère des)"
+                                    }
+                                },
+                                {
+                                    "value": "042",
+                                    "text": {
+                                        "default": "Indian Affairs and Northern Development (Department of)",
+                                        "fr": "Affaires indiennes et du Nord canadien (Ministère des)"
+                                    }
+                                },
+                                {
+                                    "value": "043",
+                                    "text": {
+                                        "default": "Canadian Intergovernmental Conference Secretariat",
+                                        "fr": "Secrétariat des conférences intergouvernementales canadiennes"
+                                    }
+                                },
+                                {
+                                    "value": "044",
                                     "text": {
                                         "default": "Western Economic Diversification (Department of)",
+                                        "fr": "Diversification de l'économie de l'Ouest canadien (Ministère de la)"
+                                    }
+                                },
+                                {
+                                    "value": "046",
+                                    "text": {
+                                        "default": "Office of the Public Sector Integrity Commissioner",
+                                        "fr": "Commissariat à l'intégrité du secteur public"
+                                    }
+                                },
+                                {
+                                    "value": "047",
+                                    "text": {
+                                        "default": "Canadian Nuclear Safety Commission",
+                                        "fr": "Commission canadienne de sûreté nucléaire"
+                                    }
+                                },
+                                {
+                                    "value": "050",
+                                    "text": {
+                                        "default": "Citizenship and Immigration (Department of)",
+                                        "fr": "Citoyenneté et de l'Immigration (Ministère de la)"
+                                    }
+                                },
+                                {
+                                    "value": "051",
+                                    "text": {
+                                        "default": "Office of the Commissioner for Federal Judicial Affairs",
+                                        "fr": "Bureau du commissaire à la magistrature fédérale"
+                                    }
+                                },
+                                {
+                                    "value": "052",
+                                    "text": {
+                                        "default": "Canada School of Public Service",
                                         "fr": "École de la fonction publique du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "053",
+                                    "text": {
+                                        "default": "Correctional Service of Canada",
+                                        "fr": "Service correctionnel du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "054",
+                                    "text": {
+                                        "default": "Statistics Canada",
+                                        "fr": "Statistique Canada"
+                                    }
+                                },
+                                {
+                                    "value": "055",
+                                    "text": {
+                                        "default": "Office of the Communications Security Establishment Commissioner",
+                                        "fr": "Bureau du commissaire du Centre de la sécurité des télécommunications"
+                                    }
+                                },
+                                {
+                                    "value": "056",
+                                    "text": {
+                                        "default": "Treasury Board Secretariat",
+                                        "fr": "Secrétariat du Conseil du Trésor"
+                                    }
+                                },
+                                {
+                                    "value": "057",
+                                    "text": {
+                                        "default": "Parole Board of Canada",
+                                        "fr": "Commission des libérations conditionnelles du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "061",
+                                    "text": {
+                                        "default": "Canadian Institutes of Health Research",
+                                        "fr": "Instituts de recherche en santé du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "062",
+                                    "text": {
+                                        "default": "Federal Economic Development Agency for Southern Ontario",
+                                        "fr": "Agence fédérale de développement économique pour le Sud de l'Ontario"
+                                    }
+                                },
+                                {
+                                    "value": "063",
+                                    "text": {
+                                        "default": "Social Sciences and Humanities Research Council",
+                                        "fr": "Conseil de recherches en sciences humaines"
+                                    }
+                                },
+                                {
+                                    "value": "066",
+                                    "text": {
+                                        "default": "Northern Pipeline Agency",
+                                        "fr": "Administration du pipe-line du Nord"
+                                    }
+                                },
+                                {
+                                    "value": "067",
+                                    "text": {
+                                        "default": "House of Commons",
+                                        "fr": "Chambre des communes"
+                                    }
+                                },
+                                {
+                                    "value": "074",
+                                    "text": {
+                                        "default": "National Energy Board",
+                                        "fr": "Office national de l'énergie"
+                                    }
+                                },
+                                {
+                                    "value": "075",
+                                    "text": {
+                                        "default": "Canadian Human Rights Commission",
+                                        "fr": "Commission canadienne des droits de la personne"
+                                    }
+                                },
+                                {
+                                    "value": "076",
+                                    "text": {
+                                        "default": "Office of the Commissioner of Official Languages",
+                                        "fr": "Commissariat aux langues officielles"
+                                    }
+                                },
+                                {
+                                    "value": "078",
+                                    "text": {
+                                        "default": "Canadian Northern Economic Development Agency",
+                                        "fr": "Agence canadienne de développement économique du Nord"
+                                    }
+                                },
+                                {
+                                    "value": "079",
+                                    "text": {
+                                        "default": "Payroll System General Ledger",
+                                        "fr": "Grand livre général du système de la paye"
+                                    }
+                                },
+                                {
+                                    "value": "080",
+                                    "text": {
+                                        "default": "Registrar of the Supreme Court of Canada",
+                                        "fr": "Registraire de la Cour suprême du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "083",
+                                    "text": {
+                                        "default": "Office of the Co-ordinator, Status of Women",
+                                        "fr": "Bureau de la coordonnatrice de la situation de la femme"
+                                    }
+                                },
+                                {
+                                    "value": "085",
+                                    "text": {
+                                        "default": "Canada Border Services Agency",
+                                        "fr": "Agence des services frontaliers du Canada"
+                                    }
+                                },
+                                {
+                                    "value": "086",
+                                    "text": {
+                                        "default": "Fisheries and Oceans (Department of)",
+                                        "fr": "Pêches et des Océans (Ministère des)"
+                                    }
+                                },
+                                {
+                                    "value": "087",
+                                    "text": {
+                                        "default": "Public Service Superannuation",
+                                        "fr": "Pension de retraite de la fonction publique"
+                                    }
+                                },
+                                {
+                                    "value": "088",
+                                    "text": {
+                                        "default": "Public Safety and Emergency Preparedness (Department of)",
+                                        "fr": "Sécurité publique et de la Protection civile (Ministère de la)"
+                                    }
+                                },
+                                {
+                                    "value": "091",
+                                    "text": {
+                                        "default": "Canada Mortgage and Housing Corporation (Crown Corporation)",
+                                        "fr": "Société canadienne d'hypothèques et de logement (Société d'État)"
+                                    }
+                                },
+                                {
+                                    "value": "095",
+                                    "text": {
+                                        "default": "Canadian Security Intelligence Service",
+                                        "fr": "Service canadien du renseignement de sécurité"
+                                    }
+                                },
+                                {
+                                    "value": "096",
+                                    "text": {
+                                        "default": "Offices of the Information and Privacy Commissioners of Canada",
+                                        "fr": "Commissariats à l'information et à la protection de la vie privée au Canada"
+                                    }
+                                },
+                                {
+                                    "value": "097",
+                                    "text": {
+                                        "default": "Receiver General",
+                                        "fr": "Receveur général"
+                                    }
+                                },
+                                {
+                                    "value": 100,
+                                    "text": {
+                                        "default": "Canadian Centre for Occupational Health and Safety",
+                                        "fr": "Centre canadien d'hygiène et de sécurité au travail"
+                                    }
+                                },
+                                {
+                                    "value": 101,
+                                    "text": {
+                                        "default": "Canadian Transportation Accident Investigation and Safety Board",
+                                        "fr": "Bureau canadien d'enquête sur les accidents de transport et de la sécurité des transports"
+                                    }
+                                },
+                                {
+                                    "value": 102,
+                                    "text": {
+                                        "default": "The National Battlefields Commission",
+                                        "fr": "Commission des champs de bataille nationaux"
+                                    }
+                                },
+                                {
+                                    "value": 103,
+                                    "text": {
+                                        "default": "Security Intelligence Review Committee",
+                                        "fr": "Comité de surveillance des activités de renseignement de sécurité"
+                                    }
+                                },
+                                {
+                                    "value": 109,
+                                    "text": {
+                                        "default": "Patented Medicine Prices Review Board",
+                                        "fr": "Conseil d'examen du prix des médicaments brevetés"
+                                    }
+                                },
+                                {
+                                    "value": 116,
+                                    "text": {
+                                        "default": "Copyright Board",
+                                        "fr": "Commission du droit d'auteur"
+                                    }
+                                },
+                                {
+                                    "value": 119,
+                                    "text": {
+                                        "default": "Canadian Space Agency",
+                                        "fr": "Agence spatiale canadienne"
+                                    }
+                                },
+                                {
+                                    "value": 122,
+                                    "text": {
+                                        "default": "Canada Revenue Agency - (Administered Activities)",
+                                        "fr": "Agence du revenu du Canada - (activités administrées)"
+                                    }
+                                },
+                                {
+                                    "value": 123,
+                                    "text": {
+                                        "default": "Export Development Canada (Crown Corporation)",
+                                        "fr": "Exportation et développement Canada (Société d'État)"
+                                    }
+                                },
+                                {
+                                    "value": 124,
+                                    "text": {
+                                        "default": "Parks Canada Agency",
+                                        "fr": "Agence Parcs Canada"
+                                    }
+                                },
+                                {
+                                    "value": 127,
+                                    "text": {
+                                        "default": "Public Works and Government Services (Department of)",
+                                        "fr": "Travaux publics et des Services gouvernementaux (Ministère des)"
+                                    }
+                                },
+                                {
+                                    "value": 130,
+                                    "text": {
+                                        "default": "Canada Revenue Agency",
+                                        "fr": "Agence du revenu du Canada"
+                                    }
+                                },
+                                {
+                                    "value": 133,
+                                    "text": {
+                                        "default": "Canadian Grain Commission",
+                                        "fr": "Commission canadienne des grains"
+                                    }
+                                },
+                                {
+                                    "value": 134,
+                                    "text": {
+                                        "default": "Canadian Dairy Commission",
+                                        "fr": "Commission canadienne du lait"
+                                    }
+                                },
+                                {
+                                    "value": 135,
+                                    "text": {
+                                        "default": "Canadian Heritage (Department of)",
+                                        "fr": "Patrimoine canadien (Ministère du)"
+                                    }
+                                },
+                                {
+                                    "value": 136,
+                                    "text": {
+                                        "default": "Canadian Food Inspection Agency",
+                                        "fr": "Agence canadienne d'inspection des aliments"
+                                    }
+                                },
+                                {
+                                    "value": 137,
+                                    "text": {
+                                        "default": "Military Police Complaints Commission",
+                                        "fr": "Commission d'examen des plaintes concernant la police militaire"
+                                    }
+                                },
+                                {
+                                    "value": 138,
+                                    "text": {
+                                        "default": "Military Grievances External Review Committee",
+                                        "fr": "Comité externe d'examen des griefs militaires"
+                                    }
+                                },
+                                {
+                                    "value": 139,
+                                    "text": {
+                                        "default": "Financial Transactions and Reports Analysis Centre of Canada",
+                                        "fr": "Centre d'analyse des opérations et déclarations financières du Canada"
+                                    }
+                                },
+                                {
+                                    "value": 141,
+                                    "text": {
+                                        "default": "Financial Consumer Agency of Canada",
+                                        "fr": "Agence de la consommation en matière financière du Canada"
+                                    }
+                                },
+                                {
+                                    "value": 142,
+                                    "text": {
+                                        "default": "Office of Infrastructure of Canada",
+                                        "fr": "Bureau de l'infrastructure du Canada"
+                                    }
+                                },
+                                {
+                                    "value": 144,
+                                    "text": {
+                                        "default": "Courts Administration Service",
+                                        "fr": "Service administratif des tribunaux judiciaires"
+                                    }
+                                },
+                                {
+                                    "value": 145,
+                                    "text": {
+                                        "default": "Library and Archives of Canada",
+                                        "fr": "Bibliothèque et Archives du Canada"
+                                    }
+                                },
+                                {
+                                    "value": 147,
+                                    "text": {
+                                        "default": "Office of the Conflict of Interest and Ethics Commissioner",
+                                        "fr": "Commissariat aux conflits d'intérêts et à l'éthique"
+                                    }
+                                },
+                                {
+                                    "value": 148,
+                                    "text": {
+                                        "default": "Public Health Agency of Canada",
+                                        "fr": "Agence de la santé publique du Canada"
+                                    }
+                                },
+                                {
+                                    "value": 151,
+                                    "text": {
+                                        "default": "Office of the Senate Ethics Officer",
+                                        "fr": "Bureau du conseiller sénatorial en éthique"
+                                    }
+                                },
+                                {
+                                    "value": 154,
+                                    "text": {
+                                        "default": "Office of the Commissioner of Lobbying",
+                                        "fr": "Commissariat au lobbying"
+                                    }
+                                },
+                                {
+                                    "value": 163,
+                                    "text": {
+                                        "default": "Shared Services Canada",
+                                        "fr": "Services partagés Canada"
+                                    }
+                                },
+                                {
+                                    "value": 165,
+                                    "text": {
+                                        "default": "Communications Security Establishment",
+                                        "fr": "Centre de la sécurité des télécommunications"
+                                    }
+                                },
+                                {
+                                    "value": 170,
+                                    "text": {
+                                        "default": "Administrative Tribunals Support Service of Canada",
+                                        "fr": "Service canadien d'appui aux tribunaux administratifs"
+                                    }
+                                },
+                                {
+                                    "value": 171,
+                                    "text": {
+                                        "default": "Canadian High Arctic Research Station",
+                                        "fr": "Station canadienne de recherche dans l'Extrême-Arctique"
+                                    }
+                                },
+                                {
+                                    "value": 176,
+                                    "text": {
+                                        "default": "Parliamentary Protective Service",
+                                        "fr": "Service de protection parlementaire"
+                                    }
+                                },
+                                {
+                                    "value": 180,
+                                    "text": {
+                                        "default": "Invest in Canada Hub",
+                                        "fr": "Investir au Canada"
+                                    }
+                                },
+                                {
+                                    "value": 183,
+                                    "text": {
+                                        "default": "Office of the Parliamentary Budget Officer",
+                                        "fr": "Bureau du directeur parlementaire du budget"
+                                    }
+                                },
+                                {
+                                    "value": 192,
+                                    "text": {
+                                        "default": "Secretariat of the National Security and Intelligence Committee of Parliamentarians",
+                                        "fr": "Secrétariat du Comité des parlementaires sur la sécurité nationale et le renseignement"
                                     }
                                 }
                             ]


### PR DESCRIPTION
Revert keys to their original values.

This creates the issue #81 Departments list need to be displayed alphabetically but is required so that the values match the saved state.