### PR TITLE
chore: Build CI with Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.4.0
         with:
-          node-version: '10.x'
-
-      - name: Cache dependencies
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: '16.x'
+          cache: npm
 
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -14,15 +14,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.4.0
         with:
-          node-version: '10.x'
-
-      - name: Cache dependencies
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: '16.x'
+          cache: npm
 
       - run: npm ci
       - run: npm test

--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -31,15 +31,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.4.0
         with:
-          node-version: '10.x'
-
-      - name: Cache dependencies
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: '16.x'
+          cache: npm
 
       - run: npm ci
 


### PR DESCRIPTION
Node 10 is EOL and support has dropped from many tools. This is why the CI is red for many runs.
Caching is now also built into setup-node, so action-cache isn't needed for this anymore.