### PR TITLE
fix #926 long lines wrapping

### DIFF
--- a/src/components/TextResult.vue
+++ b/src/components/TextResult.vue
@@ -15,7 +15,7 @@
             >{{ $t("frenchContent") }} :
           </strong>
           <p>
-            <span style="white-space: pre">{{ data.displayValue }}</span>
+            <span style="white-space: pre-wrap">{{ data.displayValue }}</span>
           </p>
         </div>
         <div>
@@ -35,10 +35,10 @@
       </div>
       <div v-if="locale !== undefined">
         <div v-if="locale == $root.$i18n.locale" class="valueResultPDF">
-          <span style="white-space: pre">{{ data.displayValue }}</span>
+          <span style="white-space: pre-wrap">{{ data.displayValue }}</span>
         </div>
         <div v-if="locale != $root.$i18n.locale" class="valueResultPDF">
-          <span style="white-space: pre">{{ this.$store.getters.getTranslationsOnResult[this.data.name] }}</span>
+          <span style="white-space: pre-wrap">{{ this.$store.getters.getTranslationsOnResult[this.data.name] }}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #926 with long lines in narratives that were not wrapping in results. The bug was introduced by fixing #777 