### PR TITLE
fix #938 make translation textarea wider

### DIFF
--- a/src/components/TextResult.vue
+++ b/src/components/TextResult.vue
@@ -26,7 +26,7 @@
             >{{ $t("englishContent") }} :
           </strong>
           <div>
-            <textarea
+            <textarea style="width: 100%"
               :value="this.$store.getters.getTranslationsOnResult[this.data.name]"
               @blur="saveTranslation($event.target.value)"
             ></textarea>


### PR DESCRIPTION
Fixes #938 by making the textarea box 100% width to capture the translation, like the output for the primary language. 